### PR TITLE
Add DynamoDB storage

### DIFF
--- a/metastore/storage.go
+++ b/metastore/storage.go
@@ -13,6 +13,7 @@ const (
 	SchemeTypeUnknown SchemeType = iota
 	SchemeTypeFile
 	SchemeTypeEtcd
+	SchemeTypeDynamodb
 )
 
 // Enum value maps for SchemeType.
@@ -80,6 +81,8 @@ func NewStorageWithUri(uri string, logger *zap.Logger) (Storage, error) {
 		return NewFileSystemStorageWithUri(uri, metastoreLogger)
 	case SchemeType_name[SchemeTypeEtcd]:
 		return NewEtcdStorageWithUri(uri, metastoreLogger)
+	case SchemeType_name[SchemeTypeDynamodb]:
+		return NewDynamodbStorage(uri, metastoreLogger)
 	default:
 		err := errors.ErrUnsupportedStorageType
 		metastoreLogger.Error(err.Error(), zap.String("scheme", u.Scheme))

--- a/metastore/storage_dynamodb.go
+++ b/metastore/storage_dynamodb.go
@@ -1,0 +1,225 @@
+package metastore
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"go.uber.org/zap"
+)
+
+const (
+	partitionKeyName = "pk"
+	sortKeyName      = "sk"
+	partitionValue   = "metadata"
+)
+
+type kv struct {
+	Partition string `dynamodbav:"pk"`
+	Path      string `dynamodbav:"sk"`
+	Version   string `dynamodbav:"version"`
+	Value     string `dynamodbav:"value"`
+}
+
+type DynamodbStorage struct {
+	dynamoSvc      *dynamodb.Client
+	tableName      string
+	root           string
+	logger         *zap.Logger
+	ctx            context.Context
+	requestTimeout time.Duration
+}
+
+func NewDynamodbStorage(uri string, logger *zap.Logger) (*DynamodbStorage, error) {
+	metastorelogger := logger.Named("dynamodb")
+
+	ctx := context.Background()
+
+	u, awsCfg, err := buildAwsCfg(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DynamodbStorage{
+		dynamoSvc:      dynamodb.NewFromConfig(awsCfg),
+		tableName:      u.Host,
+		root:           u.Path,
+		logger:         metastorelogger,
+		ctx:            ctx,
+		requestTimeout: 3 * time.Second,
+	}, nil
+}
+
+// Replace the path separator with '/'.
+func (m *DynamodbStorage) makePath(path string) string {
+	return filepath.ToSlash(filepath.Join(filepath.ToSlash(m.root), filepath.ToSlash(path)))
+}
+
+func (m *DynamodbStorage) Get(path string) ([]byte, error) {
+	fullPath := m.makePath(path)
+
+	res, err := m.dynamoSvc.GetItem(m.ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(m.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{
+				Value: partitionValue,
+			},
+			"sk": &types.AttributeValueMemberS{
+				Value: fullPath,
+			},
+		},
+	})
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return nil, err
+	}
+
+	rec := new(kv)
+	err = attributevalue.UnmarshalMap(res.Item, rec)
+	if err != nil {
+		return nil, err
+	}
+
+	return base64.RawStdEncoding.DecodeString(rec.Value)
+}
+
+func (m *DynamodbStorage) Put(path string, value []byte) error {
+	fullPath := m.makePath(path)
+
+	rec := &kv{Partition: partitionValue, Path: fullPath, Value: base64.RawURLEncoding.EncodeToString(value)}
+
+	attr, err := attributevalue.MarshalMap(rec)
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return err
+	}
+
+	// this adds a condition which checks if the sort key already exists, if it does
+	// this operation will return a condition error.
+	existCond := expression.AttributeNotExists(expression.Name(sortKeyName))
+	condExpr, err := expression.NewBuilder().WithCondition(existCond).Build()
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return err
+	}
+
+	_, err = m.dynamoSvc.PutItem(m.ctx, &dynamodb.PutItemInput{
+		TableName:                 aws.String(m.tableName),
+		Item:                      attr,
+		ConditionExpression:       condExpr.Condition(),
+		ExpressionAttributeNames:  condExpr.Names(),
+		ExpressionAttributeValues: condExpr.Values(),
+	})
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return err
+	}
+
+	return nil
+}
+
+func (m *DynamodbStorage) List(prefix string) ([]string, error) {
+	fullPath := m.makePath(prefix)
+
+	keyCond := expression.
+		Key(partitionKeyName).Equal(expression.Value(partitionValue)).
+		And(expression.Key(sortKeyName).BeginsWith(fullPath))
+
+	keyExpr, err := expression.NewBuilder().WithKeyCondition(keyCond).Build()
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return nil, err
+	}
+
+	res, err := m.dynamoSvc.Query(m.ctx, &dynamodb.QueryInput{
+		TableName:                 &m.tableName,
+		KeyConditionExpression:    keyExpr.KeyCondition(),
+		ExpressionAttributeNames:  keyExpr.Names(),
+		ExpressionAttributeValues: keyExpr.Values(),
+	})
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return nil, err
+	}
+
+	results := make([]string, len(res.Items))
+
+	for i, item := range res.Items {
+		rec := new(kv)
+		err = attributevalue.UnmarshalMap(item, rec)
+		if err != nil {
+			m.logger.Error(err.Error(), zap.String("key", fullPath))
+			return nil, err
+		}
+
+		v, err := base64.RawStdEncoding.DecodeString(rec.Value)
+		if err != nil {
+			m.logger.Error(err.Error(), zap.String("key", fullPath))
+			return nil, err
+		}
+
+		results[i] = string(v)
+	}
+
+	return results, nil
+}
+
+func (m *DynamodbStorage) Delete(path string) error {
+	fullPath := m.makePath(path)
+
+	_, err := m.dynamoSvc.DeleteItem(m.ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(m.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{
+				Value: partitionValue,
+			},
+			"sk": &types.AttributeValueMemberS{
+				Value: path,
+			},
+		},
+	})
+	if err != nil {
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return err
+	}
+
+	return nil
+}
+
+func (m *DynamodbStorage) Exists(path string) (bool, error) {
+	fullPath := m.makePath(path)
+
+	_, err := m.dynamoSvc.GetItem(m.ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(m.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{
+				Value: partitionValue,
+			},
+			"sk": &types.AttributeValueMemberS{
+				Value: path,
+			},
+		},
+	})
+	if err != nil {
+		var rne *types.ResourceNotFoundException
+		if errors.As(err, &rne) {
+			return false, nil
+		}
+
+		m.logger.Error(err.Error(), zap.String("key", fullPath))
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (m *DynamodbStorage) Close() error {
+	return nil
+}

--- a/metastore/storage_dynamodb_url.go
+++ b/metastore/storage_dynamodb_url.go
@@ -1,0 +1,31 @@
+package metastore
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+func buildAwsCfg(uri string) (*url.URL, aws.Config, error) {
+	var awsCfg aws.Config
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, awsCfg, err
+	}
+
+	ctx := context.Background()
+
+	awsCfg, err = config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, awsCfg, err
+	}
+
+	if u.Query().Has("region") {
+		awsCfg.Region = u.Query().Get("region")
+	}
+
+	return u, awsCfg, nil
+}

--- a/metastore/storage_dynamodb_url.go
+++ b/metastore/storage_dynamodb_url.go
@@ -2,7 +2,6 @@ package metastore
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -47,7 +46,6 @@ func buildOpts(u *url.URL) []func(*config.LoadOptions) error {
 }
 
 func getCredentials(u *url.URL) config.LoadOptionsFunc {
-	fmt.Println("creds", u.Query().Has("access_key_id"))
 	switch {
 	case u.Query().Has("profile"):
 		return config.WithSharedConfigProfile("test-profile")
@@ -63,8 +61,6 @@ func getCredentials(u *url.URL) config.LoadOptionsFunc {
 }
 
 func getEndpoint(u *url.URL) config.LoadOptionsFunc {
-	fmt.Println("creds", u.Query().Has("endpoint_url"))
-
 	if u.Query().Has("endpoint_url") && u.Query().Has("region") {
 		return config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(

--- a/metastore/storage_dynamodb_url.go
+++ b/metastore/storage_dynamodb_url.go
@@ -9,6 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 )
 
+// we must have a region for setting up an endpoint when testing so we use the standard default of north virginia
+const defaultSigningRegion = "us-east-1"
+
 func buildAwsCfg(uri string) (*url.URL, aws.Config, error) {
 	var awsCfg aws.Config
 
@@ -61,14 +64,21 @@ func getCredentials(u *url.URL) config.LoadOptionsFunc {
 }
 
 func getEndpoint(u *url.URL) config.LoadOptionsFunc {
-	if u.Query().Has("endpoint_url") && u.Query().Has("region") {
+	if u.Query().Has("endpoint_url") {
+
+		signingRegion := defaultSigningRegion
+
+		if u.Query().Has("region") {
+			signingRegion = u.Query().Get("region")
+		}
+
 		return config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(
 				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 					return aws.Endpoint{
 						PartitionID:   "aws",
 						URL:           u.Query().Get("endpoint_url"),
-						SigningRegion: u.Query().Get("region"),
+						SigningRegion: signingRegion,
 					}, nil
 				},
 			),

--- a/metastore_integration_test/storage_dynamodb_test.go
+++ b/metastore_integration_test/storage_dynamodb_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+package metastore_integration_test
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/mosuka/phalanx/logging"
+	"github.com/mosuka/phalanx/metastore"
+	"github.com/thanhpk/randstr"
+)
+
+func TestDynamodbStorageWithUri(t *testing.T) {
+	err := godotenv.Load(filepath.FromSlash("../.env"))
+	if err != nil {
+		t.Errorf("Failed to load .env file")
+	}
+
+	tmpDir := randstr.String(8)
+	uri := fmt.Sprintf("dynamodb://phalanx-test/metastore/newtest/%s?%s", tmpDir, buildQueryFromEnv())
+	logger := logging.NewLogger("WARN", "", 500, 3, 30, false)
+
+	dynamodbStorage, err := metastore.NewDynamodbStorage(uri, logger)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer dynamodbStorage.Close()
+}
+
+func TestDynamodbStorageGet(t *testing.T) {
+	err := godotenv.Load(filepath.FromSlash("../.env"))
+	if err != nil {
+		t.Errorf("Failed to load .env file")
+	}
+
+	tmpDir := randstr.String(8)
+	uri := fmt.Sprintf("dynamodb://phalanx-test/metastore/newtest/%s?%s", tmpDir, buildQueryFromEnv())
+	logger := logging.NewLogger("WARN", "", 500, 3, 30, false)
+
+	dynamodbStorage, err := metastore.NewDynamodbStorage(uri, logger)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer dynamodbStorage.Close()
+
+	dynamodbStorage.Put("/wikipedia_en.json", []byte("{}"))
+
+	content, err := dynamodbStorage.Get("/wikipedia_en.json")
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	if string(content) != "{}" {
+		t.Fatalf("unexpected value. %v\n", string(content))
+	}
+}
+
+func TestDynamodbStorageDelete(t *testing.T) {
+	err := godotenv.Load(filepath.FromSlash("../.env"))
+	if err != nil {
+		t.Errorf("Failed to load .env file")
+	}
+
+	tmpDir := randstr.String(8)
+	uri := fmt.Sprintf("dynamodb://phalanx-test/metastore/newtest/%s?%s", tmpDir, buildQueryFromEnv())
+	logger := logging.NewLogger("WARN", "", 500, 3, 30, false)
+
+	dynamodbStorage, err := metastore.NewDynamodbStorage(uri, logger)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer dynamodbStorage.Close()
+
+	dynamodbStorage.Put("/wikipedia_en.json", []byte("{}"))
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	dynamodbStorage.Delete("/wikipedia_en.json")
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+}
+
+func TestDynamodbStorageExists(t *testing.T) {
+	err := godotenv.Load(filepath.FromSlash("../.env"))
+	if err != nil {
+		t.Errorf("Failed to load .env file")
+	}
+
+	tmpDir := randstr.String(8)
+	uri := fmt.Sprintf("dynamodb://phalanx-test/metastore/newtest/%s?%s", tmpDir, buildQueryFromEnv())
+	logger := logging.NewLogger("INFO", "", 500, 3, 30, false)
+
+	dynamodbStorage, err := metastore.NewDynamodbStorage(uri, logger)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer dynamodbStorage.Close()
+
+	exists, err := dynamodbStorage.Exists("/wikipedia_en.json")
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	if exists != false {
+		t.Fatalf("unexpected value. %v\n", exists)
+	}
+
+	dynamodbStorage.Put("/wikipedia_en.json", []byte("{}"))
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	exists, err = dynamodbStorage.Exists("/wikipedia_en.json")
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	if exists != true {
+		t.Fatalf("unexpected value. %v\n", exists)
+	}
+}
+
+func TestDynamodbStorageList(t *testing.T) {
+	err := godotenv.Load(filepath.FromSlash("../.env"))
+	if err != nil {
+		t.Errorf("Failed to load .env file")
+	}
+
+	tmpDir := randstr.String(8)
+	uri := fmt.Sprintf("dynamodb://phalanx-test/metastore/newtest/%s?%s", tmpDir, buildQueryFromEnv())
+	logger := logging.NewLogger("WARN", "", 500, 3, 30, false)
+
+	dynamodbStorage, err := metastore.NewDynamodbStorage(uri, logger)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer dynamodbStorage.Close()
+
+	dynamodbStorage.Put("/hello.txt", []byte("hello"))
+	dynamodbStorage.Put("/world.txt", []byte("world"))
+
+	paths, err := dynamodbStorage.List("/")
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	sort.Slice(paths, func(i, j int) bool { return paths[i] < paths[j] })
+
+	if !reflect.DeepEqual(paths, []string{"/hello.txt", "/world.txt"}) {
+		t.Fatalf("unexpected %v\v", paths)
+	}
+}
+
+func buildQueryFromEnv() string {
+
+	vals := url.Values{}
+
+	vals.Add("region", os.Getenv("AWS_DEFAULT_REGION"))
+	vals.Add("endpoint_url", os.Getenv("AWS_ENDPOINT_URL"))
+	vals.Add("access_key_id", os.Getenv("AWS_ACCESS_KEY_ID"))
+	vals.Add("secret_access_key", os.Getenv("AWS_SECRET_ACCESS_KEY"))
+	vals.Add("create_table", "true")
+
+	return vals.Encode()
+}

--- a/metastore_integration_test/storage_dynamodb_test.go
+++ b/metastore_integration_test/storage_dynamodb_test.go
@@ -1,4 +1,4 @@
-////go:build integration
+//go:build integration
 
 package metastore_integration_test
 


### PR DESCRIPTION
This implements the metastore for AWS dynamodb.

1. I have implemented most of the configuration options for DynamoDB based on your URL specification in https://mosuka.github.io/phalanx/lock_store.html 
2. I have added integration tests using the infrastructure / tooling in the project
3. All the operations are "safe" for create / read and delete, there is currently no update. I added some generic errors to help with this.

So some feedback on the storage interface, I don't think the `context.Context` or logger should be stored in the `DynamodbStorage` struct, i think each call should pass the `ctx` in and the logger should be pulled from the context. This would enable integration of tracing later on, with the `ctx` propagated all the way through the service.

Need to work out how you want tests added, i have used github.com/ory/dockertest to enable use of dynamodb local inside a test, but this can also just be run with docker-compose or just started locally before running integration tests.

